### PR TITLE
Add LOD utility

### DIFF
--- a/ALifeStdDev/phylogeny/utils.py
+++ b/ALifeStdDev/phylogeny/utils.py
@@ -476,6 +476,37 @@ def abstract_asexual_lineage(lineage, attribute_list,
 
     return abstract_lineage
 
+# ===== lod ====
+
+def extract_asexual_lod(phylogeny):
+    """Given an asexual phylogeny, extract a line of descent (i.e. an unbroken li￼neage from a leaf node to a root)
+        Not guaranteed to be the only line of descent! It chooses the maximal valued leaf and minimal valued root.
+
+    Args:
+        phylogeny (networkx.DiGraph): graph object that describes a phylogeny
+        
+
+    Returns:
+        networkx.DiGraph object that describes a lineage
+    """
+
+    # Check that the lineage is asexual
+    if not is_asexual(phylogeny):
+      raise Exception("Given phylogeny is not asexual.")
+
+    if not get_extant_taxa_ids(phylogeny):
+      raise Exception("Given phylogeny has no extant taxa.")
+
+    # Get all leafs and roots
+    extant_taxa_ids = sorted(get_extant_taxa_ids(phylogeny), reverse=True)
+    root_ids = sorted(get_root_ids(phylogeny))
+
+    # Iterate through leaf/root pairs until we find a connected pair
+    for taxa_id in extant_taxa_ids:
+      for root_id in root_ids:
+        if nx.has_path(phylogeny, root_id, taxa_id):
+          return extract_asexual_lineage(phylogeny, taxa_id)
+    raise Exception("No path found.") 
 
 # ===== mrca =====
 

--- a/tests/test_phylogeny_utils.py
+++ b/tests/test_phylogeny_utils.py
@@ -292,6 +292,34 @@ def test_abstract_asexual_lineage():
     abstract_lineage_tb = phylodev.abstract_asexual_lineage(lineage, ["trait_b"])
     assert len(abstract_lineage_tb) == 2
 
+def test_extract_asexual_lod():
+    single_lineage_fname = "example_data/example-standard-toy-asexual-lineage.csv"
+    single_root_fname = "example_data/example-standard-toy-asexual-phylogeny.csv"
+    multi_root_fname = "example_data/example-standard-toy-asexual-phylogeny-multi-roots.csv"
+    sex_fname = "example_data/example-standard-toy-sexual-phylogeny.csv"
+    
+    lineage = phylodev.load_phylogeny_to_networkx(single_lineage_fname)
+    sroot = phylodev.load_phylogeny_to_networkx(single_root_fname)
+    mroot = phylodev.load_phylogeny_to_networkx(multi_root_fname)
+    sexphylo = phylodev.load_phylogeny_to_networkx(sex_fname)
+
+    # check lod for a branching lineage
+    sroot_lod = phylodev.extract_asexual_lod(sroot)
+    assert len(sroot_lod.nodes) == 3
+    assert set(sroot_lod.nodes) == set([5, 2, 0])
+
+    # check lod for a multiroot lineage 
+    mroot_lod = phylodev.extract_asexual_lod(mroot)
+    assert len(mroot_lod.nodes) == 3
+    assert set(mroot_lod.nodes) == set([8, 7, 6])
+
+    # make sure something without living taxa fails
+    with pytest.raises(Exception):
+        phylodev.extract_asexual_lod(lineage)
+
+    # make sure sexphylo fails
+    with pytest.raises(Exception):
+        phylodev.extract_asexual_lod(sexphylo)
 
 def test_get_mrca_id_asexual():
     single_root_fname = "example_data/example-standard-toy-asexual-phylogeny.csv"
@@ -366,6 +394,7 @@ if __name__ == "__main__":
     test_extract_asexual_lineage()
     test_is_asexual_lineage()
     test_abstract_asexual_lineage()
+    test_extract_asexual_lod()
     test_get_mrca_id_asexual()
     test_has_common_ancestor_asexual()
     test_get_pairwise_distances()


### PR DESCRIPTION
This pull request creates a function `extract_asexual_lod` as a simple extension of `extract_asexual_lineage`. The difference is that `extract_asexual_lod` does not require a leaf node to be identified; instead it selects the maximally-valued extant leaf node which has a root node as its ancestor, and returns the lineage with that leaf and root. 

In the future this function could be extended to not only handle living taxa, but right now that's what it does 